### PR TITLE
Change SigningContext signature from rsa.PrivateKey to crypto.Signer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/beevik/etree v1.1.0
 	github.com/jonboulle/clockwork v0.2.0
+	github.com/stretchr/testify v1.6.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/russellhaering/goxmldsig
+
+go 1.14
+
+require (
+	github.com/beevik/etree v1.1.0
+	github.com/jonboulle/clockwork v0.2.0
+)

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
+github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/jonboulle/clockwork v0.2.0 h1:J2SLSdy7HgElq8ekSl2Mxh6vrRNFxqbXGenYH2I02Vs=
+github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jonboulle/clockwork v0.2.0 h1:J2SLSdy7HgElq8ekSl2Mxh6vrRNFxqbXGenYH2I02Vs=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/keystore.go
+++ b/keystore.go
@@ -1,6 +1,7 @@
 package dsig
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -9,7 +10,7 @@ import (
 )
 
 type X509KeyStore interface {
-	GetKeyPair() (privateKey *rsa.PrivateKey, cert []byte, err error)
+	GetKeyPair() (privateKey crypto.Signer, cert []byte, err error)
 }
 
 type X509ChainStore interface {
@@ -33,7 +34,7 @@ type MemoryX509KeyStore struct {
 	cert       []byte
 }
 
-func (ks *MemoryX509KeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
+func (ks *MemoryX509KeyStore) GetKeyPair() (crypto.Signer, []byte, error) {
 	return ks.privateKey, ks.cert, nil
 }
 

--- a/sign.go
+++ b/sign.go
@@ -3,7 +3,6 @@ package dsig
 import (
 	"crypto"
 	"crypto/rand"
-	"crypto/rsa"
 	_ "crypto/sha1"
 	_ "crypto/sha256"
 	"encoding/base64"
@@ -183,8 +182,7 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 			return nil, err
 		}
 	}
-
-	rawSignature, err := rsa.SignPKCS1v15(rand.Reader, key, ctx.Hash, digest)
+	rawSignature, err := key.Sign(rand.Reader, digest, ctx.Hash)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +247,7 @@ func (ctx *SigningContext) SignString(content string) ([]byte, error) {
 	var signature []byte
 	if key, _, err := ctx.KeyStore.GetKeyPair(); err != nil {
 		return nil, fmt.Errorf("unable to fetch key for signing: %v", err)
-	} else if signature, err = rsa.SignPKCS1v15(rand.Reader, key, ctx.Hash, digest); err != nil {
+	} else if signature, err = key.Sign(rand.Reader, digest, ctx.Hash); err != nil {
 		return nil, fmt.Errorf("error signing: %v", err)
 	}
 	return signature, nil

--- a/tls_keystore.go
+++ b/tls_keystore.go
@@ -1,6 +1,7 @@
 package dsig
 
 import (
+	"crypto"
 	"crypto/rsa"
 	"crypto/tls"
 	"fmt"
@@ -17,7 +18,7 @@ var (
 type TLSCertKeyStore tls.Certificate
 
 //GetKeyPair implements X509KeyStore using the underlying tls.Certificate
-func (d TLSCertKeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
+func (d TLSCertKeyStore) GetKeyPair() (crypto.Signer, []byte, error) {
 	pk, ok := d.PrivateKey.(*rsa.PrivateKey)
 
 	if !ok {


### PR DESCRIPTION
- Change SigningContext signature from `*rsa.PrivateKey` to `crypto.Signer` to support signing with HSM